### PR TITLE
Fix: Fetch history of all branches & tags

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_PUSH_TO_REPO_TOKEN }}
+          fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
           java-version: '15'


### PR DESCRIPTION
## Before this PR

Whenever we get an automatic PR to upgrade the dependencies, it'd never update and thus we weren't able to leverage it's ability to [force push](https://github.com/markelliot/update-gradle-deps/blob/8a352b285e5b26c5b7b9fe3be463821d3bbd35f0/action.yml#L67) into the working branch any new changes.

Currently, we fail with the following error:
```
fatal: ambiguous argument 'origin/auto/versions': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

## After this PR

We now checkout the repo with all it's branches & tags, and thus - running the `git` command should now be succeeding.